### PR TITLE
Allow unweighted MS and RT scores

### DIFF
--- a/msmsrt_scorer/lib/tests/Unittests_exact_solvers.py
+++ b/msmsrt_scorer/lib/tests/Unittests_exact_solvers.py
@@ -161,7 +161,7 @@ class TestChainFactorGraph(unittest.TestCase):
         R, Q = CFG.R_sum, CFG.Q_sum
 
         # == FORWARD ==
-        D = CFG.D
+        D = CFG.D_rt
         # R-Messages passed from the leaf nodes
         np.testing.assert_equal(R[(0, 0)][0], candidates[0]["score"] ** (1.0 - D))
         np.testing.assert_equal(R[(1, 1)][1], candidates[1]["score"] ** (1.0 - D))


### PR DESCRIPTION
By passing None to the retention order weight, we can now have two weights
D_ms = 1.0 and D_rt = 1.0. This allows more flexible application of the
library.